### PR TITLE
ci: move to python-build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
+        python -m pip install --upgrade pip build
         pip install anytree systemdunitparser
     - name: Lint with flake8
       run: |
@@ -32,11 +32,11 @@ jobs:
     - name: Build
       run: |
         cd systemdlint
-        python setup.py build
+        python -m build --sdist --wheel
     - name: Install
       run: |
         cd systemdlint
-        python3 setup.py install
+        python -m pip install --user dist/*.whl
     - name: Test
       run: |
         cd systemdlint


### PR DESCRIPTION
as directly calling setup.py is deprecated