### PR TITLE
Fix ExecValue prefix check

### DIFF
--- a/systemdlint/systemdlint/cls/value.py
+++ b/systemdlint/systemdlint/cls/value.py
@@ -64,13 +64,13 @@ class Value(object):
     def IsAllowedValue(self, value):
         return False
 
-    def AdditionalErrors(self, value, item, runargs):
+    def AdditionalErrors(self, value, item, runargs, search = lambda x,y: y in x):
         res = []
         if not self.__conditionals.keys():
             return res
         cond = value.replace(self.CleanValue(value), "")
         for k, v in self.__conditionals.items():
-            if k in cond and v:
+            if search(cond, k) and v:
                 module = importlib.import_module("systemdlint.cls.error")
                 class_ = getattr(module, v)
                 res.append(class_(item.Line, item.File))
@@ -715,7 +715,7 @@ class ExecValue(Value):
         return False
 
     def AdditionalErrors(self, value, item, args):
-        res = super().AdditionalErrors(value, item, args)
+        res = super().AdditionalErrors(value, item, args, search = lambda x,y: x.startswith(y))
         com = self.CleanValue(value).split(" ")[0]
         if not os.path.exists(Helper.GetPath(args.rootpath, com)):
             res.append(ErrorExecNotFound(item.Line, item.File))

--- a/systemdlint/tests/manual/NoFailureCheck/2.31/bad/Service_ExecStart_ls@.service
+++ b/systemdlint/tests/manual/NoFailureCheck/2.31/bad/Service_ExecStart_ls@.service
@@ -1,0 +1,6 @@
+[Unit]
+Description=Foo
+
+[Service]
+Type=oneshot
+ExecStart=-/bin/ls %i

--- a/systemdlint/tests/manual/NoFailureCheck/2.31/good/Service_ExecStart_ls@.service
+++ b/systemdlint/tests/manual/NoFailureCheck/2.31/good/Service_ExecStart_ls@.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=Foo
+
+[Service]
+Type=oneshot
+ExecStartPre=/bin/ls /foo/bar/%i
+ExecStart=/bin/ls -l /foo/bar/%i
+ExecStartPost=/bin/ls /foo/bar-zap/%i


### PR DESCRIPTION
The systemdlint tool's `NoFailureCheck`/`ErrorCommandCouldFail` triggers false-positives on the `AdditionalErrors` function of `ExecValue`. The function leverages the parent class version which checks if a character is contained within the field's value. However, the relevant characters only matter if they are a prefix in this case, not simply contained. As such, there are false positives for ExecStart* commands which contain a `-` in the command (or in the arguments supplied to it).

By providing a bit more flexibility to the check, we can provide an argument to determine what type of string search to use which allows the ExecValue to perform a prefix check instead of just within. All other Value classes should be unaffected and all ExecValue functions should care exclusively about prefixes. I have tested locally with a yocto build and some unit files that were showing false positives.