### PR TITLE
Add special values for `RuntimeWatchdogSec` setting

### DIFF
--- a/systemdlint/systemdlint/cls/value.py
+++ b/systemdlint/systemdlint/cls/value.py
@@ -332,7 +332,7 @@ class DeviceNodeValue(Value):
 
 
 class TimeValue(Value):
-    def __init__(self, conditional={}):
+    def __init__(self, conditional={}, specials=[]):
         super().__init__(conditional)
         self._kv = {
             "days": "d",
@@ -365,12 +365,15 @@ class TimeValue(Value):
             "y": "y",
             "µs": "us"
         }
+        self.__specials = specials
 
     def IsAllowedValue(self, value):
         val = self.CleanValue(value)
         if not val.isnumeric():
             if val == "infinity":
                 # All time values should accept 'infinity'
+                return True
+            if val in self.__specials:
                 return True
             for m in re.finditer(r"^((?P<val>\d+)\s*(?P<mul>\w+)\s*)+".format("|".join(self._kv.keys())), val):
                 val = val.replace(m.group(0), "")

--- a/systemdlint/systemdlint/conf/knownSettings.py
+++ b/systemdlint/systemdlint/conf/knownSettings.py
@@ -555,7 +555,7 @@ KNOWN_SETTINGS = [
     Setting(section="Manager", name="NoNewPrivileges", allowedValue=BooleanValue(), sinceRel="2.39"),
     Setting(section="Manager", name="NUMAPolicy", allowedValue=EnumValue(["default", "preferred", "bind", "interleave", "local"]), sinceRel="2.43"),
     Setting(section="Manager", name="RebootWatchdogSec", allowedValue=TimeValue(), sinceRel="2.43"),
-    Setting(section="Manager", name="RuntimeWatchdogSec", allowedValue=TimeValue()),
+    Setting(section="Manager", name="RuntimeWatchdogSec", allowedValue=TimeValue(specials=["off", "default"])),
     Setting(section="Manager", name="ShowStatus", allowedValue=BooleanValue()),
     Setting(section="Manager", name="ShutdownWatchdogSec", allowedValue=TimeValue(), tillRel="2.42"),
     Setting(section="Manager", name="StatusUnitFormat", allowedValue=EnumValue(["name", "description", "combined"]), sinceRel="2.49"),


### PR DESCRIPTION
Besides fixing the specific setting, this introduces general support for special values of time values.

Fixes #71 